### PR TITLE
Fix PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,9 +1,9 @@
 # Author: Dmitriy Smirnov <other@igus.lv>
 pkgname=downgrader
 pkgver=1.7.0
-pkgrel=4
+pkgrel=5
 pkgdesc="Powerful packages downgrader for Archlinux. Works with libalpm, ARM and pacman logs"
-arch=('any')
+arch=('i686' 'x86_64')
 depends=('pacman' 'intltool' 'sudo')
 license=("GPL")
 url="https://github.com/DimaSmirnov/Archlinux-downgrader"


### PR DESCRIPTION
Since your application is binary, it depends on architecture. 'any' package is a package that being building under one architecture will work under the other. If you build your package under 'i686' architecture, it will not work under 'x86_64'.
