### PR TITLE
Added environment variables for external archive servers

### DIFF
--- a/actions.c
+++ b/actions.c
@@ -44,6 +44,7 @@ char* GetChoiseForPackage( char *package) {
 }
 int IsPackageAvailable(char *package) {
     alpm_siglevel_t siglevel=0;
+    char *env_repo;
 
     db = alpm_register_syncdb(alpm_handle, "core", siglevel);
     pkg = alpm_db_get_pkg(db,(const char*)package);
@@ -69,6 +70,15 @@ int IsPackageAvailable(char *package) {
     if (pkgr) { int i = IsPackageInstalled(package); if (i==1) { installed_pkg_ver = alpm_pkg_get_version(pkg);
         //printf ("4. installed_pkg_ver: %s\n", installed_pkg_ver); //DEBUG
         return 0; } else return 1; }
+    env_repo=getenv("DOWNGRADE_REPO");
+    if(env_repo!=NULL) {
+        db = alpm_register_syncdb(alpm_handle, env_repo, siglevel);
+        pkg = alpm_db_get_pkg(db,(const char*)package);
+        pkgr= alpm_pkg_get_url(pkg);
+        if (pkgr) { int i = IsPackageInstalled(package); if (i==1) { installed_pkg_ver = alpm_pkg_get_version(pkg);
+            //printf ("4. installed_pkg_ver: %s\n", installed_pkg_ver); //DEBUG
+            return 0; } else return 1; }
+    }
     return 2;
 
 // return 0 - pkg available

--- a/ala.c
+++ b/ala.c
@@ -1,12 +1,17 @@
 int ReadALA(char *package) {
 	char substr[2];
-	char ala_path[150], tmp_string2[200];
-	char *fullpkg, *ptr;
+	char ala_path[250], tmp_string2[200];
+	char *fullpkg, *ptr, *env_url;
 	
 	strcpy(tmp_string,package);
 	strncpy(substr, package, 1);
 	substr[1]='\0';
-	sprintf (ala_path, "https://archive.archlinux.org/packages/%s/%s/",substr,tmp_string);
+	env_url=getenv("DOWNGRADE_ALA_URL");
+	if(env_url!=NULL) {
+		sprintf (ala_path, "%s/%s/%s/",env_url,substr,tmp_string);
+	} else {
+		sprintf (ala_path, "https://archive.archlinux.org/packages/%s/%s/",substr,tmp_string);
+	}
 	strcpy(package,tmp_string);
 
 	chunk.memory = malloc(1);


### PR DESCRIPTION
#### Changes

* Added environment variable DOWNGRADE_ALA_URL to get external server url
* Added environment variable DOWNGRADE_REPO to get packages from external repository

#### Description

This PR allows using a custom ALA URL to downgrade packages from official and custom repositories.

#### Usage:
```bash
export DOWNGRADE_ALA_URL="https://repo.itmettke.de/aur-archive/packages"
export DOWNGRADE_REPO="aur-archlinux"
downgrader spotify
```